### PR TITLE
Ozone: adapter updates version 2.9.0

### DIFF
--- a/modules/ozoneBidAdapter.js
+++ b/modules/ozoneBidAdapter.js
@@ -7,7 +7,8 @@ import {
   isArray,
   contains,
   mergeDeep,
-  parseUrl
+  parseUrl,
+  generateUUID
 } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
@@ -16,15 +17,15 @@ import {getPriceBucketString} from '../src/cpmBucketManager.js';
 import { Renderer } from '../src/Renderer.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 const BIDDER_CODE = 'ozone';
-const ORIGIN = 'https://elb.the-ozone-project.com'; // applies only to auction & cookie
+const ORIGIN = 'https://elb.the-ozone-project.com' // applies only to auction & cookie
 const AUCTIONURI = '/openrtb2/auction';
 const OZONECOOKIESYNC = '/static/load-cookie.html';
 const OZONE_RENDERER_URL = 'https://prebid.the-ozone-project.com/ozone-renderer.js';
 const ORIGIN_DEV = 'https://test.ozpr.net';
-const OZONEVERSION = '2.8.0';
+const OZONEVERSION = '2.9.0';
 export const spec = {
   gvlid: 524,
-  aliases: [{code: 'lmc', gvlid: 524}],
+  aliases: [{code: 'lmc', gvlid: 524}, {code: 'newspassid', gvlid: 524}, {code: 'newspass', gvlid: 524}],
   version: OZONEVERSION,
   code: BIDDER_CODE,
   supportedMediaTypes: [VIDEO, BANNER],
@@ -36,7 +37,8 @@ export const spec = {
     'keyPrefix': 'oz',
     'auctionUrl': ORIGIN + AUCTIONURI,
     'cookieSyncUrl': ORIGIN + OZONECOOKIESYNC,
-    'rendererUrl': OZONE_RENDERER_URL
+    'rendererUrl': OZONE_RENDERER_URL,
+    'batchRequests': false /* you can change this to true OR override it in the config: config.ozone.batchRequests */
   },
   loadWhitelabelData(bid) {
     if (this.propertyBag.whitelabel) { return; }
@@ -73,6 +75,9 @@ export const spec = {
         this.propertyBag.whitelabel.auctionUrl = bidderConfig.endpointOverride.auctionUrl;
       }
     }
+    if (bidderConfig.hasOwnProperty('batchRequests')) {
+      this.propertyBag.whitelabel.batchRequests = bidderConfig.batchRequests;
+    }
     try {
       if (arr.hasOwnProperty('auction') && arr.auction === 'dev') {
         logInfo('GET: auction=dev');
@@ -94,11 +99,14 @@ export const spec = {
   getRendererUrl() {
     return this.propertyBag.whitelabel.rendererUrl;
   },
+  isBatchRequests() {
+    return this.propertyBag.whitelabel.batchRequests;
+  },
   isBidRequestValid(bid) {
     this.loadWhitelabelData(bid);
     logInfo('isBidRequestValid : ', config.getConfig(), bid);
     let adUnitCode = bid.adUnitCode; // adunit[n].code
-    let err1 = 'VALIDATION FAILED : missing {param} : siteId, placementId and publisherId are REQUIRED';
+    let err1 = 'VALIDATION FAILED : missing {param} : siteId, placementId and publisherId are REQUIRED'
     if (!(bid.params.hasOwnProperty('placementId'))) {
       logError(err1.replace('{param}', 'placementId'), adUnitCode);
       return false;
@@ -199,7 +207,7 @@ export const spec = {
       let placementId = placementIdOverrideFromGetParam || this.getPlacementId(ozoneBidRequest); // prefer to use a valid override param, else the bidRequest placement Id
       obj.id = ozoneBidRequest.bidId; // this causes an error if we change it to something else, even if you update the bidRequest object: "WARNING: Bidder ozone made bid for unknown request ID: mb7953.859498327448. Ignoring."
       obj.tagid = placementId;
-      let parsed = parseUrl(getRefererInfo().page);
+      let parsed = parseUrl(this.getRefererInfo().page);
       obj.secure = parsed.protocol === 'https' ? 1 : 0;
       let arrBannerSizes = [];
       if (!ozoneBidRequest.hasOwnProperty('mediaTypes')) {
@@ -262,9 +270,7 @@ export const spec = {
       obj.placementId = placementId;
       deepSetValue(obj, 'ext.prebid', {'storedrequest': {'id': placementId}});
       obj.ext[whitelabelBidder] = {};
-      // TODO: fix auctionId/transactionID leak: https://github.com/prebid/Prebid.js/issues/9781
       obj.ext[whitelabelBidder].adUnitCode = ozoneBidRequest.adUnitCode; // eg. 'mpu'
-      obj.ext[whitelabelBidder].transactionId = ozoneBidRequest.transactionId; // this is the transactionId PER adUnit, common across bidders for this unit
       if (ozoneBidRequest.params.hasOwnProperty('customData')) {
         obj.ext[whitelabelBidder].customData = ozoneBidRequest.params.customData;
       }
@@ -326,7 +332,7 @@ export const spec = {
     let userExtEids = deepAccess(validBidRequests, '0.userIdAsEids', []); // generate the UserIDs in the correct format for UserId module
     ozoneRequest.site = {
       'publisher': {'id': htmlParams.publisherId},
-      'page': getRefererInfo().page,
+      'page': this.getRefererInfo().page,
       'id': htmlParams.siteId
     };
     ozoneRequest.test = config.getConfig('debug') ? 1 : 0;
@@ -355,13 +361,34 @@ export const spec = {
     if (config.getConfig('coppa') === true) {
       deepSetValue(ozoneRequest, 'regs.coppa', 1);
     }
+    let ozUuid = generateUUID();
+    if (this.isBatchRequests()) {
+      logInfo('going to batch the requests');
+      let arrRet = []; // return an array of objects containing data describing max 10 bids
+      for (let i = 0; i < tosendtags.length; i += 10) {
+        ozoneRequest.id = ozUuid; // Unique ID of the bid request, provided by the exchange. (REQUIRED)
+        ozoneRequest.imp = tosendtags.slice(i, i + 10);
+        ozoneRequest.ext = extObj;
+        deepSetValue(ozoneRequest, 'source.tid', ozUuid);// RTB 2.5 : tid is Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges).
+        deepSetValue(ozoneRequest, 'user.ext.eids', userExtEids);
+        if (ozoneRequest.imp.length > 0) {
+          arrRet.push({
+            method: 'POST',
+            url: this.getAuctionUrl(),
+            data: JSON.stringify(ozoneRequest),
+            bidderRequest: bidderRequest
+          });
+        }
+      }
+      logInfo('batch request going to return : ', arrRet);
+      return arrRet;
+    }
+    logInfo('requests will not be batched.');
     if (singleRequest) {
       logInfo('buildRequests starting to generate response for a single request');
-      ozoneRequest.id = bidderRequest.auctionId; // Unique ID of the bid request, provided by the exchange.
-      ozoneRequest.auctionId = bidderRequest.auctionId; // not sure if this should be here?
+      ozoneRequest.id = ozUuid; // Unique ID of the bid request, provided by the exchange. (REQUIRED)
       ozoneRequest.imp = tosendtags;
       ozoneRequest.ext = extObj;
-      deepSetValue(ozoneRequest, 'source.tid', bidderRequest.auctionId);// RTB 2.5 : tid is Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges).
       deepSetValue(ozoneRequest, 'user.ext.eids', userExtEids);
       var ret = {
         method: 'POST',
@@ -378,11 +405,10 @@ export const spec = {
       logInfo('buildRequests starting to generate non-single response, working on imp : ', imp);
       let ozoneRequestSingle = Object.assign({}, ozoneRequest);
       imp.ext[whitelabelBidder].pageAuctionId = bidderRequest['auctionId']; // make a note in the ext object of what the original auctionId was, in the bidderRequest object
-      ozoneRequestSingle.id = imp.ext[whitelabelBidder].transactionId; // Unique ID of the bid request, provided by the exchange.
-      ozoneRequestSingle.auctionId = imp.ext[whitelabelBidder].transactionId; // not sure if this should be here?
+      deepSetValue(ozoneRequestSingle, 'source.tid', ozUuid);// RTB 2.5 : tid is Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges).
+      ozoneRequestSingle.id = generateUUID(); // Unique ID of the bid request, provided by the exchange. (REQUIRED)
       ozoneRequestSingle.imp = [imp];
       ozoneRequestSingle.ext = extObj;
-      deepSetValue(ozoneRequestSingle, 'source.tid', bidderRequest.auctionId);// RTB 2.5 : tid is Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges).
       deepSetValue(ozoneRequestSingle, 'user.ext.eids', userExtEids);
       logInfo('buildRequests RequestSingle (for non-single) = ', ozoneRequestSingle);
       return {
@@ -686,9 +712,28 @@ export const spec = {
     return null;
   },
   getGetParametersAsObject() {
-    let parsed = parseUrl(getRefererInfo().page);
+    let parsed = parseUrl(this.getRefererInfo().location);
     logInfo('getGetParametersAsObject found:', parsed.search);
     return parsed.search;
+  },
+  getRefererInfo() {
+    if (getRefererInfo().hasOwnProperty('location')) {
+      logInfo('FOUND location on getRefererInfo OK (prebid >= 7); will use getRefererInfo for location & page');
+      return getRefererInfo();
+    } else {
+      logInfo('DID NOT FIND location on getRefererInfo (prebid < 7); will use legacy code that ALWAYS worked reliably to get location & page ;-)');
+      try {
+        return {
+          page: top.location.href,
+          location: top.location.href
+        };
+      } catch (e) {
+        return {
+          page: window.location.href,
+          location: window.location.href
+        };
+      }
+    }
   },
   blockTheRequest() {
     let ozRequest = this.getWhitelabelConfigItem('ozone.oz_request');

--- a/modules/ozoneBidAdapter.md
+++ b/modules/ozoneBidAdapter.md
@@ -73,6 +73,8 @@ adUnits = [{
                 }];
 ```
 
+
+```
 //Instream Video adUnit
 
 adUnits = [{


### PR DESCRIPTION


<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature

## Description of change
- changes required for PB 8 https://github.com/prebid/Prebid.js/issues/8573 - removed transaction IDs
- added our own id (as per ortb spec & required by ozone server)
- added support for batching 10 impression objects with a config switch 
- adding newspass as an alias
- update the spec tests for this

<!-- For new bidder adapters, please provide the following


```
engineering@ozoneproject.com
rupesh@ozoneproject.com

Testpages:

https://www.ardm.io/ozone/2.9.0/3-adslots-ozone-pb8-20230620-batch.html?pbjs_debug=true
https://www.ardm.io/ozone/2.9.0/3-adslots-ozone-pb8-20230620-nobatch.html?pbjs_debug=true
https://www.ardm.io/ozone/2.9.0/3-adslots-ozone-pb8-20230620-batch-no-gpid.html?pbjs_debug=true - config switches the gpid off

see .md file for bid parameters.

```



## Other information
[<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->](https://github.com/prebid/Prebid.js/issues/8573)